### PR TITLE
Add lb_arn_suffix_output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -10,6 +10,10 @@ output "lb_arn" {
   value = aws_lb.app_lb.arn
 }
 
+output "lb_arn_suffix" {
+  value = aws_lb.app_lb.arn_suffix
+}
+
 output "lb_secure_listener" {
   value = aws_lb_listener.secure_listener.arn
 }


### PR DESCRIPTION
I need this value in order to terraform cloudwatch alarms by referring to the module variable instead of hardcoding. cc @KyleSudu 