### PR TITLE
Add option for circuit breaker failure event notification.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.70.0"
+  hashes = [
+    "h1:7rt5BdmiBJOFlNHstjwg2tDP4b+/+4sSvjz5ywP4HJE=",
+    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
+    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
+    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
+    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
+    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
+    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
+    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
+    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
+    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
+    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
+    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
+  ]
+}

--- a/ecs.tf
+++ b/ecs.tf
@@ -64,3 +64,8 @@ resource "aws_ecs_service" "main_service" {
     ]
   }
 }
+
+data "aws_ecs_service" "main_service" {
+  cluster_arn  = data.aws_ecs_cluster.target_cluster.arn
+  service_name = aws_ecs_service.main_service.name
+}

--- a/events.tf
+++ b/events.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudwatch_event_rule" "ecs_task_deployment_failure" {
+  count = var.circuit_breaker_failure_events_enabled ? 1 : 0
+
+  name        = "${aws_ecs_service.main_service.name}-deployment-failure"
+  description = "Task deployment failed"
+
+  event_pattern = jsonencode({
+    detail-type = ["ECS Deployment State Change"]
+    source      = ["aws.ecs"]
+    resources   = [data.aws_ecs_service.main_service.arn]
+    detail      = {
+      eventType = ["ERROR"]
+      eventName = ["SERVICE_DEPLOYMENT_FAILED"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "ecs_task_deployment_failure_sns" {
+  count = var.circuit_breaker_failure_events_enabled ? 1 : 0
+
+  rule      = aws_cloudwatch_event_rule.ecs_task_deployment_failure[0].name
+  target_id = "SendToSNS"
+  arn       = coalesce(var.circuit_breaker_sns_topic_arn, aws_sns_topic.ecs_task_deployment_failure_sns_topic[0].arn)
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,17 @@
+data "aws_iam_policy_document" "ecs_task_deployment_failure_sns_topic_policy" {
+  count = var.circuit_breaker_failure_events_enabled ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["SNS:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    resources = [
+      coalesce(var.circuit_breaker_sns_topic_arn, aws_sns_topic.ecs_task_deployment_failure_sns_topic[0].arn)
+    ]
+  }
+}

--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,12 @@
+resource "aws_sns_topic" "ecs_task_deployment_failure_sns_topic" {
+  count = var.circuit_breaker_failure_events_enabled && var.circuit_breaker_sns_topic_arn == null ? 1 : 0
+
+  name = "${aws_ecs_service.main_service.name}-deployment-failure"
+}
+
+resource "aws_sns_topic_policy" "ecs_task_deployment_failure_sns_topic_policy" {
+  count = var.circuit_breaker_failure_events_enabled ? 1 : 0
+
+  arn    = coalesce(var.circuit_breaker_sns_topic_arn, aws_sns_topic.ecs_task_deployment_failure_sns_topic[0].arn)
+  policy = data.aws_iam_policy_document.ecs_task_deployment_failure_sns_topic_policy[0].json
+}

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,14 @@ variable "circuit_breaker_rollback_enabled" {
   default     = false
   description = "Should we enable rollback when a circuit breaker triggers? Defaults to false."
 }
+
+variable "circuit_breaker_failure_events_enabled" {
+  default     = false
+  description = "Should we create EventBridge events for when a failure is detected by the circuit breaker? Defaults to false."
+}
+
+variable "circuit_breaker_sns_topic_arn" {
+  type        = string
+  default     = null
+  description = "The arn of the SNS topic to publish deployment circuit breaker failure messages to. If not provided, a SNS topic will be provided by this module."
+}


### PR DESCRIPTION
This will allow you to set up a task to notify via SNS whenever the circuit breaker is activated due to a deployment failure. It will create an SNS topic for you but it also allows you to specify your own SNS topic should you wish to group these events for multiple apps together.